### PR TITLE
Include LICENSE in sdist, various nits

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,3 @@ use_parentheses = True
 
 [mypy]
 ignore_missing_imports = True
-python_version = 3.4

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     version=version,
     author="John Reese",
     author_email="john@noswap.com",
-    url="https://github.com/jreese/cpgame",
+    url="https://github.com/jreese/objectsinpython",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Heads up the build is failing because `make full` references a directory that doesn't exist.  Not sure how this ever worked on CI.